### PR TITLE
Backend support for SMTLib types (particularly bitvectors and floats)

### DIFF
--- a/src/main/scala/viper/silver/ast/Expression.scala
+++ b/src/main/scala/viper/silver/ast/Expression.scala
@@ -387,6 +387,18 @@ object DomainFuncApp {
     DomainFuncApp(func.name,args,typVarMap)(pos, info, func.typ.substitute(typVarMap), func.domainName, errT)
 }
 
+// --- References to built-in SMT Lib functions
+
+case class SMTFuncApp(smtfunc: SMTFunc, args: Seq[Exp])
+                     (val pos: Position, val info: Info, override val typ : Type, val errT: ErrorTrafo)
+  extends AbstractDomainFuncApp with PossibleTrigger {
+  override lazy val check : Seq[ConsistencyError] = args.flatMap(Consistency.checkPure)
+  def getArgs = args
+  def withArgs(newArgs: Seq[Exp]) = SMTFuncApp(smtfunc, newArgs)(pos,info,typ, errT)
+  override def func = (p: Program) => smtfunc
+  def funcname = smtfunc.name
+}
+
 // --- Field and predicate accesses
 
 /** A common trait for expressions accessing a location. */

--- a/src/main/scala/viper/silver/ast/Expression.scala
+++ b/src/main/scala/viper/silver/ast/Expression.scala
@@ -391,10 +391,8 @@ object DomainFuncApp {
 
 case class SMTFuncApp(smtfunc: SMTFunc, args: Seq[Exp])
                      (val pos: Position, val info: Info, override val typ : Type, val errT: ErrorTrafo)
-  extends AbstractDomainFuncApp with PossibleTrigger {
+  extends AbstractDomainFuncApp {
   override lazy val check : Seq[ConsistencyError] = args.flatMap(Consistency.checkPure)
-  def getArgs = args
-  def withArgs(newArgs: Seq[Exp]) = SMTFuncApp(smtfunc, newArgs)(pos,info,typ, errT)
   override def func = (p: Program) => smtfunc
   def funcname = smtfunc.name
 }

--- a/src/main/scala/viper/silver/ast/Program.scala
+++ b/src/main/scala/viper/silver/ast/Program.scala
@@ -705,3 +705,7 @@ case object NotOp extends UnOp with BoolDomainFunc {
   lazy val priority = 10
   lazy val fixity = Prefix
 }
+
+
+case class SMTFunc(name: String, smtName: String, override val typ: Type, override val formalArgs: Seq[LocalVarDecl]) extends Node with AbstractDomainFunc with BuiltinDomainFunc
+

--- a/src/main/scala/viper/silver/ast/Type.scala
+++ b/src/main/scala/viper/silver/ast/Type.scala
@@ -183,3 +183,5 @@ case class TypeVar(name: String) extends Type {
 
   //def !=(other: TypeVar) = name != other
 }
+
+case class SMTType(boogieName: String, smtName: String) extends AtomicType

--- a/src/main/scala/viper/silver/ast/pretty/PrettyPrinter.scala
+++ b/src/main/scala/viper/silver/ast/pretty/PrettyPrinter.scala
@@ -618,6 +618,7 @@ object FastPrettyPrinter extends FastPrettyPrinterBase with BracketPrettyPrinter
       case dt@DomainType(domainName, typVarsMap) =>
         val typArgs = dt.typeParameters map (t => show(typVarsMap.getOrElse(t, t)))
         text(domainName) <> (if (typArgs.isEmpty) nil else brackets(ssep(typArgs, char (',') <> space)))
+      case SMTType(boogieName, _) => boogieName
     }
   }
 
@@ -766,6 +767,8 @@ object FastPrettyPrinter extends FastPrettyPrinterBase with BracketPrettyPrinter
       text(funcname) <> parens(ssep(args map show, char (',') <> space))
     case DomainFuncApp(funcname, args, _) =>
       text(funcname) <> parens(ssep(args map show, char (',') <> space))
+    case SMTFuncApp(func, args) =>
+      text(func.name) <> parens(ssep(args map show, char(',') <> space))
 
     case EmptySeq(elemTyp) =>
       text("Seq[") <> showType(elemTyp) <> "]()"

--- a/src/main/scala/viper/silver/ast/utility/Expressions.scala
+++ b/src/main/scala/viper/silver/ast/utility/Expressions.scala
@@ -32,6 +32,7 @@ object Expressions {
          | _: PermExp
          | _: FuncApp
          | _: DomainFuncApp
+         | _: SMTFuncApp
          | _: LocationAccess
          | _: AbstractLocalVar
          | _: SeqExp

--- a/src/main/scala/viper/silver/ast/utility/Nodes.scala
+++ b/src/main/scala/viper/silver/ast/utility/Nodes.scala
@@ -106,6 +106,7 @@ object Nodes {
           case FuncApp(_, args) => args
           case DomainFuncApp(_, args, m) =>
             args ++ m.keys ++ m.values
+          case SMTFuncApp(_, args) => args
 
           case EmptySeq(elemTyp) => Seq(elemTyp)
           case ExplicitSeq(elems) => elems

--- a/src/main/scala/viper/silver/ast/utility/SMTTypeFactories.scala
+++ b/src/main/scala/viper/silver/ast/utility/SMTTypeFactories.scala
@@ -1,0 +1,73 @@
+package viper.silver.ast.utility
+
+import viper.silver.ast.{Bool, Int, LocalVarDecl, SMTFunc, SMTType}
+
+/**
+  * A factory for fixed-size bitvectors that offers convenient access to bitvector types, as well as
+  * function definitions for unary and binary functions on bitvectors, as well as conversions from and
+  * to integers.
+  */
+case class BVFactory(size: Int) {
+  lazy val typ = SMTType(s"bv${size}", s"(_ BitVec ${size})")
+
+  def xor(name: String) = SMTFunc(name, "bvxor", typ, Seq(LocalVarDecl("x", typ)(), LocalVarDecl("y", typ)()))
+  def and(name: String) = SMTFunc(name, "bvand", typ, Seq(LocalVarDecl("x", typ)(), LocalVarDecl("y", typ)()))
+  def or(name: String) = SMTFunc(name, "bvor", typ, Seq(LocalVarDecl("x", typ)(), LocalVarDecl("y", typ)()))
+  def add(name: String) = SMTFunc(name, "bvadd", typ, Seq(LocalVarDecl("x", typ)(), LocalVarDecl("y", typ)()))
+  def mul(name: String) = SMTFunc(name, "bvmul", typ, Seq(LocalVarDecl("x", typ)(), LocalVarDecl("y", typ)()))
+  def shl(name: String) = SMTFunc(name, "bvshl", typ, Seq(LocalVarDecl("x", typ)(), LocalVarDecl("y", typ)()))
+  def shr(name: String) = SMTFunc(name, "bvshr", typ, Seq(LocalVarDecl("x", typ)(), LocalVarDecl("y", typ)()))
+
+  def not(name: String) = SMTFunc(name, "bvnot", typ, Seq(LocalVarDecl("x", typ)()))
+  def neg(name: String) = SMTFunc(name, "bvneg", typ, Seq(LocalVarDecl("x", typ)()))
+
+  def from_int(name: String) = SMTFunc(name, s"(_ int2bv ${size})", typ, Seq(LocalVarDecl("x", Int)()))
+  def to_int(name: String) = SMTFunc(name, s"(_ bv2int ${size})", Int, Seq(LocalVarDecl("x", typ)()))
+  def from_nat(name: String) = SMTFunc(name, s"(_ nat2bv ${size})", typ, Seq(LocalVarDecl("x", Int)()))
+  def to_nat(name: String) = SMTFunc(name, s"(_ bv2nat ${size})", Int, Seq(LocalVarDecl("x", typ)()))
+}
+
+/**
+  * Rounding modes for floating point operations.
+  */
+object RoundingMode extends Enumeration {
+  type RoundingMode = Value
+  val RNE, RNA, RTP, RTN, RTZ = Value
+}
+import RoundingMode._
+
+/**
+  * A factory for IEEE floating point numbers with "exp" bits for the exponent, "mant" bits for the significant,
+  * including the hidden bit, and a given rounding mode for all operations that use one.
+  * Offers access to types, unary and binary operations, comparisons, and conversions from and to
+  * bitvectors of size exp + mant.
+  */
+case class FloatFactory(mant: Int, exp: Int, roundingMode: RoundingMode) {
+
+  lazy val typ = SMTType(s"float${mant}e${exp}", s"(_ FloatingPoint ${exp} ${mant})")
+
+  def neg(name: String) = SMTFunc(name, "fp.neg", typ, Seq(LocalVarDecl("x", typ)()))
+  def abs(name: String) = SMTFunc(name, "fp.abs", typ, Seq(LocalVarDecl("x", typ)()))
+
+  def add(name: String) = SMTFunc(name, s"fp.add ${roundingMode}", typ, Seq(LocalVarDecl("x", typ)(), LocalVarDecl("y", typ)()))
+  def sub(name: String) = SMTFunc(name, s"fp.sub ${roundingMode}", typ, Seq(LocalVarDecl("x", typ)(), LocalVarDecl("y", typ)()))
+  def mul(name: String) = SMTFunc(name, s"fp.mul ${roundingMode}", typ, Seq(LocalVarDecl("x", typ)(), LocalVarDecl("y", typ)()))
+  def div(name: String) = SMTFunc(name, s"fp.div ${roundingMode}", typ, Seq(LocalVarDecl("x", typ)(), LocalVarDecl("y", typ)()))
+  def min(name: String) = SMTFunc(name, s"fp.min ${roundingMode}", typ, Seq(LocalVarDecl("x", typ)(), LocalVarDecl("y", typ)()))
+  def max(name: String) = SMTFunc(name, s"fp.max ${roundingMode}", typ, Seq(LocalVarDecl("x", typ)(), LocalVarDecl("y", typ)()))
+
+  def eq(name: String) = SMTFunc(name, s"fp.eq", Bool, Seq(LocalVarDecl("x", typ)(), LocalVarDecl("y", typ)()))
+  def leq(name: String) = SMTFunc(name, s"fp.leq", Bool, Seq(LocalVarDecl("x", typ)(), LocalVarDecl("y", typ)()))
+  def geq(name: String) = SMTFunc(name, s"fp.geq", Bool, Seq(LocalVarDecl("x", typ)(), LocalVarDecl("y", typ)()))
+  def lt(name: String) = SMTFunc(name, s"fp.lt", Bool, Seq(LocalVarDecl("x", typ)(), LocalVarDecl("y", typ)()))
+  def gt(name: String) = SMTFunc(name, s"fp.gt", Bool, Seq(LocalVarDecl("x", typ)(), LocalVarDecl("y", typ)()))
+
+  def isZero(name: String) = SMTFunc(name, s"fp.isZero", Bool, Seq(LocalVarDecl("x", typ)()))
+  def isInfinite(name: String) = SMTFunc(name, s"fp.isInfinite", Bool, Seq(LocalVarDecl("x", typ)()))
+  def isNaN(name: String) = SMTFunc(name, s"fp.isNaN", Bool, Seq(LocalVarDecl("x", typ)()))
+  def isNegative(name: String) = SMTFunc(name, s"fp.isNegative", Bool, Seq(LocalVarDecl("x", typ)()))
+  def isPositive(name: String) = SMTFunc(name, s"fp.isPositive", Bool, Seq(LocalVarDecl("x", typ)()))
+
+  def from_bv(name: String) = SMTFunc(name, s"(_ to_fp ${exp} ${mant}) ", typ, Seq(LocalVarDecl("x", BVFactory(mant+exp).typ)()))
+  def to_bv(name: String) = SMTFunc(name, s"(_ fp.to_sbv ${exp+mant}) ${roundingMode} ", BVFactory(mant+exp).typ, Seq(LocalVarDecl("x", typ)()))
+}

--- a/src/main/scala/viper/silver/ast/utility/Types.scala
+++ b/src/main/scala/viper/silver/ast/utility/Types.scala
@@ -69,7 +69,7 @@ object Types {
     * @return The list of transitive type constituents of `typ`.
     */
   def typeConstituents(typ: Type): List[Type] = typ match {
-    case Int | Bool | Perm | Ref | InternalType | _: TypeVar | Wand => Nil
+    case Int | Bool | Perm | Ref | InternalType | _: TypeVar | Wand | _: SMTType => Nil
     case dt: DomainType => dt.typeParameters.map(_.substitute(dt.typVarsMap)).toList
     case SeqType(elementType) => elementType :: typeConstituents(elementType)
     case SetType(elementType) => elementType :: typeConstituents(elementType)


### PR DESCRIPTION
>  **Pull request** :twisted_rightwards_arrows: created by bitbucket user **meilers** on 2019-07-23 17:02
> Last updated on 2019-07-29 15:54
> Original Bitbucket pull request id: 127
>
> Participants:
>
> * bitbucket user **alexander_summers** (reviewer)
> * bitbucket user **vakaras** (reviewer) :heavy_check_mark:
> * bitbucket user **meilers**
> * bitbucket user **mschwerhoff** (reviewer)
>
> Source: https://github.com/fpoli/viper-silver/commit/071af4a412cd83c2dcccaeedd8a742b54ecf79aa on [`meilers_smt_types`](https://github.com/fpoli/viper-silver/tree/meilers_smt_types)
> Destination: https://github.com/fpoli/viper-silver/commit/7696e8eec1ab9361cb36a5b5109863f2601cf415 on [`master`](https://github.com/fpoli/viper-silver/tree/master)
>
> State: **`OPEN`**

This PR adds backend support for theories supported by SMTLib \(in Silicon’s case\) and Boogie \(in Carbon’s case\) to Viper. In SMTLib, there are a number of such types, but afaik Boogie only supports bitvectors and IEEE floating point numbers.

The PR adds additional nodes to the AST to represent the corresponding types and functions, and there are PRs for Silicon and Carbon that teach the backends how to translate those types and functions. There is no integration with the parser \(yet\), so those types and functions can be used only by frontends that directly create the AST nodes.

In particular, there are the following additions:

* SMTType\(boogieType, smtType\): Represents a type with name “boogieType” in Boogie and name “smtType” in SMTLib.
* SMTFunc\(name, smtName, type, formalArgs\): A function that is called “smtName” in SMTLib and can be referred to inside the Viper Program as “name”. The distinction between internal name and Viper name is helpful because SMTLib overloads function names, e.g. function “bvxor” XORs bitvectors of different lenghts, so one might want to use different function names “bvxor32” and “bvxor16” for bitvectors of length 32 and 16, respectively.
* SMTFuncApp\(smtFunc, args\): Applications of those functions. Note that SMTFuncs do not have to be defined explicitly in the Viper Program, they are only referred to by SMTFuncApps.
* Factory classes BVFactors\(size\) and FloatFactory\(exp, mant, round\) that give convenient access to types and functions for bitvectors of a given size, as well as floats of a certain type \(i.e., a given number of bits for the exponent and the significand, and a given rounding mode\).
